### PR TITLE
enhance portability

### DIFF
--- a/policy/security-manager-policy-reload
+++ b/policy/security-manager-policy-reload
@@ -33,7 +33,7 @@ END
 find "$POLICY_PATH" -name "usertype-*.profile" |
 while read file
 do
-    bucket="`echo $file | sed -r 's|.*/usertype-(.*).profile$|USER_TYPE_\U\1|'`"
+    bucket="`echo $file | sed -r 's|.*/usertype-(.*).profile$|USER_TYPE_\1|' | tr '[:lower:]' '[:upper:]'`"
 
     # Re-create the bucket with empty contents
     cyad --delete-bucket=$bucket || true

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -3,7 +3,7 @@ SET(COMMON_VERSION ${COMMON_VERSION_MAJOR}.0.2)
 
 PKG_CHECK_MODULES(COMMON_DEP
     REQUIRED
-    libsystemd-journal
+    libsystemd
     libsmack
     db-util
     cynara-admin

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -1,6 +1,6 @@
 PKG_CHECK_MODULES(SERVER_DEP
     REQUIRED
-    libsystemd-daemon
+    libsystemd
     )
 
 FIND_PACKAGE(Boost REQUIRED)


### PR DESCRIPTION
These patches are the result of using SecurityManager on a Yocto-based
Linux (see https://github.com/01org/meta-intel-iot-security) which
differs from Tizen in some aspects (systemd compiled differently,
Busybox instead of coreutils).

It would be nice to get them included upstream.
